### PR TITLE
fix autolab_core yaml load error due to ruamel.yaml deprecate old load()

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update -y && \
 
 # Install all other python deps
 RUN git clone https://github.com/mmatl/pyopengl.git && python3 -m pip install --no-cache-dir ./pyopengl
+RUN python3 -m pip install "ruamel.yaml<0.18.0"
 RUN python3 -m pip install --no-cache-dir trimesh python-fcl autolab_core numpy pandas pyrender tqdm matplotlib
 
 RUN mkdir -p IPC_sim/build


### PR DESCRIPTION
ruamel.yaml is needed for autolab_core loading YAML config. However, the old-style load() is deprecated in [ruamel.yaml>=0.18.0](https://pypi.org/project/ruamel.yaml/). So it is needed to add version constraint in Dokerfile before install autolab_core.